### PR TITLE
Remove python 2.7 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install from source with:
 
 ### Requirements
 
-* Python 2.7+ or Python 3.3+
+* Python 3.3+
 
 ## Usage
 


### PR DESCRIPTION
We no longer test with Python 2.7 as GitHub action no longer supports it. 

https://github.com/ConvertAPI/convertapi-python/commit/7da792dd4cd7b54fd344058ae235584c6152bac1

https://github.com/actions/setup-python/issues/672