### PR TITLE
Switch to authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,13 @@ Install from source with:
 
 ### Configuration
 
-You can get your secret at https://www.convertapi.com/a
+You can get your API credentials at https://www.convertapi.com/a
 
 ```python
 import convertapi
 
-convertapi.api_secret = 'your-api-secret'
+convertapi.api_credentials = 'your-api-secret-or-token'
 ```
-
-If you prefer to use [token and API key](https://www.convertapi.com/doc/auth#token), you can configure like this:
-
-```python
-import convertapi
-
-convertapi.api_token = 'your-api-token'
-convertapi.api_key = 000000 # your api key
-```
-
-If both API secret and token are configured, token will be used.
 
 #### Proxy configuration
 

--- a/convertapi/__init__.py
+++ b/convertapi/__init__.py
@@ -7,9 +7,7 @@ from .api import convert, user
 
 # configuration
 
-api_secret = None
-api_key = None
-api_token = None
+api_credentials = None
 base_uri = 'https://v2.convertapi.com/'
 user_agent = 'ConvertAPI-Python/' + __version__
 timeout = 1800

--- a/convertapi/client.py
+++ b/convertapi/client.py
@@ -54,17 +54,12 @@ class Client:
 		return r.json()
 
 	def __url(self, path):
-		if convertapi.api_token != None and convertapi.api_key != None:
-			return "%s%s?Token=%s&ApiKey=%d" % (convertapi.base_uri, path, convertapi.api_token, convertapi.api_key)
-
-		if convertapi.api_token != None:
-			return "%s%s?Token=%s" % (convertapi.base_uri, path, convertapi.api_token)
-
-		return "%s%s?Secret=%s" % (convertapi.base_uri, path, convertapi.api_secret)
+		return convertapi.base_uri + path
 
 	def __session(self):
 		s = requests.Session()
 		s.headers.update({ 'User-Agent': convertapi.user_agent })
+		s.headers.update({ 'Authorization': 'Bearer ' + convertapi.api_credentials })
 		s.verify = convertapi.verify_ssl
 
 		return s

--- a/examples/conversions_chaining.py
+++ b/examples/conversions_chaining.py
@@ -2,7 +2,7 @@ import convertapi
 import os
 import tempfile
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Short example of conversions chaining, the PDF pages extracted and saved as separated JPGs and then ZIP'ed
 # https://www.convertapi.com/doc/chaining

--- a/examples/convert_stream.py
+++ b/examples/convert_stream.py
@@ -3,7 +3,7 @@ import os
 import io
 import tempfile
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Example of using content stream to convert to pdf
 # https://www.convertapi.com/txt-to-pdf

--- a/examples/convert_url_to_pdf.py
+++ b/examples/convert_url_to_pdf.py
@@ -2,7 +2,7 @@ import convertapi
 import os
 import tempfile
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Example of converting Web Page URL to PDF file
 # https://www.convertapi.com/web-to-pdf

--- a/examples/convert_word_to_pdf_and_png.py
+++ b/examples/convert_word_to_pdf_and_png.py
@@ -2,7 +2,7 @@ import convertapi
 import os
 import tempfile
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Example of saving Word docx to PDF and to PNG
 # https://www.convertapi.com/docx-to-pdf

--- a/examples/create_pdf_thumbnail.py
+++ b/examples/create_pdf_thumbnail.py
@@ -2,7 +2,7 @@ import convertapi
 import os
 import tempfile
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Example of extracting first page from PDF and then chaining conversion PDF page to JPG.
 # https://www.convertapi.com/pdf-to-extract

--- a/examples/retrieve_user_information.py
+++ b/examples/retrieve_user_information.py
@@ -1,7 +1,7 @@
 import convertapi
 import os
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Retrieve user information
 # https://www.convertapi.com/doc/user

--- a/examples/split_and_merge_pdf.py
+++ b/examples/split_and_merge_pdf.py
@@ -2,7 +2,7 @@ import convertapi
 import os
 import tempfile
 
-convertapi.api_secret = os.environ['CONVERT_API_SECRET'] # your api secret
+convertapi.api_credentials = os.environ['CONVERT_API_SECRET'] # your api secret or token
 
 # Example of extracting first and last pages from PDF and then merging them back to new PDF.
 # https://www.convertapi.com/pdf-to-split

--- a/tests/test_convertapi.py
+++ b/tests/test_convertapi.py
@@ -10,17 +10,15 @@ from nose.tools import *
 
 class TestConvertapi(utils.TestCase):
 	def setUp(self):
-		convertapi.api_secret = os.environ['CONVERT_API_SECRET']
-		convertapi.api_key = None
-		convertapi.api_token = None
+		convertapi.api_credentials = os.environ['CONVERT_API_SECRET']
 		convertapi.max_parallel_uploads = 10
 
 	def test_defaults(self):
 		eq_('https://v2.convertapi.com/', convertapi.base_uri)
 
 	def test_configuration(self):
-		convertapi.api_secret = 'TEST'
-		eq_('TEST', convertapi.api_secret)
+		convertapi.api_credentials = 'TEST'
+		eq_('TEST', convertapi.api_credentials)
 
 	def test_convert_file(self):
 		result = convertapi.convert('pdf', { 'File': 'examples/files/test.docx' })
@@ -71,24 +69,9 @@ class TestConvertapi(utils.TestCase):
 
 	@raises(convertapi.ApiError)
 	def test_api_error(self):
-		convertapi.api_secret = 'TEST'
+		convertapi.api_credentials = 'TEST'
 		convertapi.convert('pdf', { 'Url': 'https://www.w3.org/TR/PNG/iso_8859-1.txt' })
 
 	def test_user_info(self):
 		user_info = convertapi.user()
 		assert user_info['Active']
-
-	@responses.activate
-	def test_with_token(self):
-		convertapi.api_token = 'TEST'
-		responses.add(responses.POST, 'https://v2.convertapi.com/convert/web/to/pdf?Token=TEST', json = { 'ConversionCost': 123 })
-		result = convertapi.convert('pdf', { 'Url': 'dummyurl' })
-		assert result.conversion_cost == 123
-
-	@responses.activate
-	def test_with_token_and_api_key(self):
-		convertapi.api_token = 'TEST'
-		convertapi.api_key = 1
-		responses.add(responses.POST, 'https://v2.convertapi.com/convert/web/to/pdf?Token=TEST&ApiKey=1', json = { 'ConversionCost': 123 })
-		result = convertapi.convert('pdf', { 'Url': 'dummyurl' })
-		assert result.conversion_cost == 123


### PR DESCRIPTION
Will pass authorization bearer header instead of params.
Also renaming `api_secret` to `api_credentials`, because it accepts both secret and token.

https://github.com/ConvertAPI/convertapi-library-python/issues/48