### PR TITLE
Change default upload and download timeouts to None

### DIFF
--- a/convertapi/__init__.py
+++ b/convertapi/__init__.py
@@ -15,8 +15,8 @@ user_agent = 'ConvertAPI-Python/' + __version__
 timeout = 1800
 conversion_timeout = None
 conversion_timeout_delta = 10
-upload_timeout = 1800
-download_timeout = 1800
+upload_timeout = None
+download_timeout = None
 max_parallel_uploads = 10
 verify_ssl = True
 


### PR DESCRIPTION
There is an issue with python httplib on windows. Timeout handling slows down file upload.

https://github.com/ConvertAPI/convertapi-library-python/issues/46

@paulius-petkus 